### PR TITLE
convert bool query parms to lower case

### DIFF
--- a/src/templates/ApiClient.mustache
+++ b/src/templates/ApiClient.mustache
@@ -285,6 +285,10 @@ namespace {{packageName}}.Client
                 }
                 return flattenedString.ToString();
             }
+            else if (obj is bool)
+            {
+                return Convert.ToString(obj).ToLower();
+            }
             else
                 return Convert.ToString (obj);
         }


### PR DESCRIPTION
boolean query parms get casted to a capitalized string (True, False), which is unusable by swagger (requires true, false). Converting to lower case will fix this.