### PR TITLE
[ADT-417] load outside swagger specs

### DIFF
--- a/src/templates/cloneApiSwagger.sh.mustache
+++ b/src/templates/cloneApiSwagger.sh.mustache
@@ -1,3 +1,4 @@
 git clone --no-checkout https://github.com/gas-buddy/{{{repoName}}} {{{repoDirectory}}}
 cd {{{repoDirectory}}}
 git checkout HEAD ./api
+git checkout HEAD package.json


### PR DESCRIPTION
In the specs of some of our services, we reference swagger documents that are from other projects.

E.g from ad-api:

In package.json:
```json
"dependencies": {
    "@gasbuddy/campaign-serv-spec": "1.0.3"
````

In api/ad-api.yaml:
```yaml
definitions:
    $ref:
    - '../node_modules/@gasbuddy/campaign-serv-spec/campaign-serv-spec.json#definitions'
```

In order for swagger specs like this to be collated properly, specs in "package.json" must be loaded first.
This PR `npm install`s the gasbuddy specs defined in a package's package.json before attempting to collate the swagger document.
