### PR TITLE
[CS-455] Make the nuget packages ids differentiate from the project names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,12 @@ If you don't want to install java or maven.  Simply run `run-gb-service` in orde
 ## Generating code from a swagger spec
 In order to generate the code from a swagger spec, you can `npm run generate-from-spec arg1 arg2 arg3`. Where 
 * arg1 is the path to the Swagger Doc
-* arg2 is the output directory
+* arg2 is the output directory and the nuget package id
 * arg3 is the name of the package
+Example:
+```
+npm run generate-from-spec identity-serv-spec.json identity-serv-client IdentityServClient
+```
 
 ## Workflow for updating repo
 It's a bit difficult to get git working in the container with ssh. So for the time being here is a workflow.

--- a/src/generateFromSpec.js
+++ b/src/generateFromSpec.js
@@ -10,7 +10,7 @@ function generateFromSpec() {
   childProcess.execSync(`java -jar ./../swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate   -i ${swaggerPath}   -l csharp   -o ${outputDirectory} --additional-properties packageName=${packageName} -t ./src/templates`);
   createFileFromTemplate('./src/templates/app_test.config.mustache', `${outputDirectory}/src/${packageName}.Test/app.config`, { packageName });
   createFileFromTemplate('./src/templates/appveyor.yml.mustache', `${outputDirectory}/appveyor.yml`, { packageName });
-  createFileFromTemplate('./src/templates/nuget.nuspec.mustache', `${outputDirectory}/src/${packageName}/${packageName}.nuspec`, { projectName: packageName, nugetPackageName: packageName });
+  createFileFromTemplate('./src/templates/nuget.nuspec.mustache', `${outputDirectory}/src/${packageName}/${packageName}.nuspec`, { projectName: packageName, nugetPackageName: outputDirectory });
 }
 
 generateFromSpec();


### PR DESCRIPTION
Had to change the script instead of the template because the script was mapping both keys to the same value so the template didn't have access to arg2.