### PR TITLE
Add OpenAPI Generator migration documentation

### DIFF
--- a/docs/openapi-generator-migration.md
+++ b/docs/openapi-generator-migration.md
@@ -137,9 +137,39 @@ var response = await api.GetSomethingAsync();
 }
 ```
 
-## Custom Templates
+## GasBuddy Custom Templates (ConfigurationManager Support)
 
-To customize the generated code (e.g., to add ConfigurationManager support):
+We have custom templates that add `ConfigurationManager.AppSettings` support, similar to the original swagger-csharp-client.
+
+### Using GasBuddy Templates
+
+```bash
+docker run --rm \
+  -v "$(pwd):/local" \
+  openapitools/openapi-generator-cli generate \
+  -i /local/api/my-api-spec.yaml \
+  -g csharp \
+  -o /local/output/my-api-client \
+  -t /local/openapi-templates/csharp-gasbuddy \
+  --additional-properties=packageName=MyApiClient,targetFramework=net48,library=generichost
+```
+
+### Configuration Keys
+
+Add these to your `app.config` or `web.config`:
+
+```xml
+<appSettings>
+  <add key="MyApiClient.Host" value="https://api.example.com" />
+  <add key="MyApiClient.Key" value="your-api-key-here" />
+</appSettings>
+```
+
+See `openapi-templates/csharp-gasbuddy/README.md` for full documentation.
+
+## Creating New Custom Templates
+
+To customize the generated code further:
 
 ### 1. Extract Default Templates
 

--- a/docs/openapi-generator-migration.md
+++ b/docs/openapi-generator-migration.md
@@ -1,0 +1,226 @@
+# Migrating to OpenAPI Generator for C# Clients
+
+This document describes how to generate C# API clients from OpenAPI 3.x specifications using OpenAPI Generator as a replacement for the Swagger 2.0-based swagger-csharp-client.
+
+## Why Migrate?
+
+| Feature | swagger-csharp-client | OpenAPI Generator |
+|---------|----------------------|-------------------|
+| OpenAPI 2.0 (Swagger) | ✓ | ✓ |
+| OpenAPI 3.0/3.1 | ✗ | ✓ |
+| Java Required | Yes (swagger-codegen) | No (Docker available) |
+| Custom Templates | Mustache | Mustache |
+| Active Development | Limited | Active |
+
+## Prerequisites
+
+- Docker installed and running
+- OpenAPI 3.x specification file (bundled into a single file)
+
+## Quick Start
+
+### 1. Bundle Your OpenAPI Spec (if using multiple files)
+
+If your API spec is split across multiple files, bundle it first:
+
+```bash
+# Using redocly
+npx @redocly/cli bundle api/my-api.yaml -o api/my-api-spec.yaml
+
+# Or using swagger-pack (for Swagger 2.0)
+swagger-pack api/my-api.yaml > api/my-api-spec.yaml
+```
+
+### 2. Generate C# Client with Docker
+
+```bash
+docker run --rm \
+  -v "$(pwd):/local" \
+  openapitools/openapi-generator-cli generate \
+  -i /local/api/my-api-spec.yaml \
+  -g csharp \
+  -o /local/output/my-api-client \
+  --additional-properties=packageName=MyApiClient,targetFramework=net48
+```
+
+### Available Target Frameworks
+
+| Framework | Value |
+|-----------|-------|
+| .NET Framework 4.7 | `net47` |
+| .NET Framework 4.8 | `net48` |
+| .NET Standard 2.0 | `netstandard2.0` |
+| .NET Standard 2.1 | `netstandard2.1` |
+| .NET 8.0 | `net8.0` |
+| .NET 9.0 | `net9.0` |
+
+Multiple targets can be specified with semicolons: `net48;netstandard2.0`
+
+## Common Options
+
+### Additional Properties
+
+```bash
+--additional-properties=packageName=MyApiClient,targetFramework=net48,packageVersion=1.0.0
+```
+
+| Property | Description | Example |
+|----------|-------------|---------|
+| `packageName` | Name of the generated package | `MyApiClient` |
+| `targetFramework` | Target .NET framework | `net48` |
+| `packageVersion` | Version of the package | `1.0.0` |
+| `sourceFolder` | Source folder for generated code | `src` |
+| `nullableReferenceTypes` | Enable nullable reference types | `true` |
+
+### Full Example with All Common Options
+
+```bash
+docker run --rm \
+  -v "$(pwd):/local" \
+  openapitools/openapi-generator-cli generate \
+  -i /local/api/auth-device-serv-spec.yaml \
+  -g csharp \
+  -o /local/output/auth-device-serv-client \
+  --additional-properties=packageName=AuthDeviceServClient,targetFramework=net48,packageVersion=1.0.0
+```
+
+## Generated Project Structure
+
+```
+output/
+├── MyApiClient.sln              # Solution file
+├── appveyor.yml                 # CI configuration
+├── docs/
+│   ├── apis/                    # API documentation (markdown)
+│   └── models/                  # Model documentation (markdown)
+└── src/
+    ├── MyApiClient/
+    │   ├── Api/                 # API classes
+    │   ├── Client/              # HTTP client infrastructure
+    │   ├── Model/               # Data models
+    │   └── Extensions/          # DI extensions
+    └── MyApiClient.Test/        # Unit tests
+```
+
+## Using the Generated Client
+
+### With Dependency Injection (Recommended)
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using MyApiClient.Api;
+using MyApiClient.Client;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureApi((context, services, options) =>
+    {
+        options.AddApiHttpClients(client =>
+        {
+            client.BaseAddress = new Uri("https://api.example.com");
+        });
+    })
+    .Build();
+
+var api = host.Services.GetRequiredService<IMyApi>();
+var response = await api.GetSomethingAsync();
+```
+
+### Configuration via appsettings.json
+
+```json
+{
+  "ApiClient": {
+    "BaseUrl": "https://api.example.com",
+    "ApiKey": "your-api-key"
+  }
+}
+```
+
+## Custom Templates
+
+To customize the generated code (e.g., to add ConfigurationManager support):
+
+### 1. Extract Default Templates
+
+```bash
+docker run --rm \
+  -v "$(pwd):/local" \
+  openapitools/openapi-generator-cli author template \
+  -g csharp \
+  -o /local/templates/csharp
+```
+
+### 2. Modify Templates
+
+Edit the Mustache templates in `templates/csharp/` as needed.
+
+### 3. Generate with Custom Templates
+
+```bash
+docker run --rm \
+  -v "$(pwd):/local" \
+  openapitools/openapi-generator-cli generate \
+  -i /local/api/my-api-spec.yaml \
+  -g csharp \
+  -o /local/output/my-api-client \
+  -t /local/templates/csharp \
+  --additional-properties=packageName=MyApiClient,targetFramework=net48
+```
+
+## Differences from swagger-csharp-client
+
+### HTTP Client
+
+- **Old**: RestSharp
+- **New**: HttpClient with HttpClientFactory
+
+### Configuration
+
+- **Old**: `ConfigurationManager.AppSettings["PackageName.Host"]`
+- **New**: Dependency injection with `IServiceCollection`
+
+### Serialization
+
+- **Old**: Newtonsoft.Json
+- **New**: System.Text.Json (can be configured)
+
+## CI/CD Integration
+
+The generated project includes `appveyor.yml` for AppVeyor CI. For other CI systems:
+
+### GitHub Actions Example
+
+```yaml
+name: Build C# Client
+
+on:
+  push:
+    paths:
+      - 'api/**'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate C# Client
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/local" \
+            openapitools/openapi-generator-cli generate \
+            -i /local/api/my-api-spec.yaml \
+            -g csharp \
+            -o /local/client \
+            --additional-properties=packageName=MyApiClient,targetFramework=net48
+
+      - name: Build Client
+        run: dotnet build client/MyApiClient.sln
+```
+
+## Resources
+
+- [OpenAPI Generator Documentation](https://openapi-generator.tech/docs/generators/csharp)
+- [OpenAPI Generator GitHub](https://github.com/OpenAPITools/openapi-generator)
+- [Available Generators](https://openapi-generator.tech/docs/generators)

--- a/openapi-templates/csharp-gasbuddy/README.md
+++ b/openapi-templates/csharp-gasbuddy/README.md
@@ -1,0 +1,89 @@
+# GasBuddy Custom C# Templates for OpenAPI Generator
+
+Custom Mustache templates for OpenAPI Generator that add `ConfigurationManager.AppSettings` support for .NET Framework projects.
+
+## Features
+
+- **Configuration-driven host**: Read API base URL from `app.config` or `web.config`
+- **Configuration-driven API key**: Read API key from `app.config` or `web.config`
+- **Fallback support**: Falls back to default values if config not present
+
+## Configuration Keys
+
+The templates use the following app settings keys:
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `{PackageName}.Host` | Base URL of the API | `https://auth-device.gasbuddy.io` |
+| `{PackageName}.Key` | API key for authentication | `your-api-key-here` |
+
+For example, if your package is named `AuthDeviceServClient`:
+
+```xml
+<appSettings>
+  <add key="AuthDeviceServClient.Host" value="https://auth-device.gasbuddy.io" />
+  <add key="AuthDeviceServClient.Key" value="your-api-key-here" />
+</appSettings>
+```
+
+## Usage
+
+### Generate Client with Custom Templates
+
+```bash
+docker run --rm \
+  -v "$(pwd):/local" \
+  openapitools/openapi-generator-cli generate \
+  -i /local/api/my-api-spec.yaml \
+  -g csharp \
+  -o /local/output/my-api-client \
+  -t /local/openapi-templates/csharp-gasbuddy \
+  --additional-properties=packageName=MyApiClient,targetFramework=net48,library=generichost
+```
+
+### Key Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `-t /local/openapi-templates/csharp-gasbuddy` | Path to custom templates |
+| `--additional-properties=library=generichost` | Use the generichost library (required for these templates) |
+
+## Project Configuration
+
+After generating, ensure your `.csproj` includes the System.Configuration reference:
+
+```xml
+<ItemGroup>
+  <Reference Include="System.Configuration" />
+</ItemGroup>
+```
+
+## Template Modifications
+
+### ClientUtils.mustache
+
+Modified to add:
+
+1. `using System.Configuration;` import
+2. `CONFIG_KEY_PREFIX` constant set to package name
+3. `BASE_ADDRESS` changed from constant to property that reads from ConfigurationManager
+4. `ApiKey` property that reads from ConfigurationManager
+5. `DEFAULT_BASE_ADDRESS` constant as fallback
+
+## Updating Templates
+
+If you need to update these templates for a newer version of OpenAPI Generator:
+
+1. Extract the latest templates:
+   ```bash
+   docker run --rm -v "$(pwd):/local" openapitools/openapi-generator-cli \
+     author template -g csharp -o /local/templates-latest
+   ```
+
+2. Compare with our customizations:
+   ```bash
+   diff templates-latest/libraries/generichost/ClientUtils.mustache \
+        openapi-templates/csharp-gasbuddy/libraries/generichost/ClientUtils.mustache
+   ```
+
+3. Merge any upstream changes while preserving our customizations

--- a/openapi-templates/csharp-gasbuddy/libraries/generichost/ClientUtils.mustache
+++ b/openapi-templates/csharp-gasbuddy/libraries/generichost/ClientUtils.mustache
@@ -1,0 +1,439 @@
+{{>partial_header}}
+{{#nrt}}
+#nullable enable
+
+{{/nrt}}
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Configuration;{{#useCompareNetObjects}}
+using KellermanSoftware.CompareNetObjects;{{/useCompareNetObjects}}
+{{#models}}
+{{#-first}}
+using {{packageName}}.{{modelPackage}};
+{{/-first}}
+{{/models}}
+using System.Runtime.CompilerServices;
+
+{{>Assembly}}namespace {{packageName}}.{{clientPackage}}
+{
+    /// <summary>
+    /// Utility functions providing some benefit to API client consumers.
+    /// </summary>
+    {{>visibility}} static {{#net70OrLater}}partial {{/net70OrLater}}class ClientUtils
+    {
+        {{#useCompareNetObjects}}
+        /// <summary>
+        /// An instance of CompareLogic.
+        /// </summary>
+        public static CompareLogic compareLogic;
+
+        /// <summary>
+        /// Static constructor to initialise compareLogic.
+        /// </summary>
+        static ClientUtils()
+        {
+            {{#equatable}}
+            ComparisonConfig comparisonConfig = new{{^net70OrLater}} ComparisonConfig{{/net70OrLater}}();
+            comparisonConfig.UseHashCodeIdentifier = true;
+            {{/equatable}}
+            compareLogic = new{{^net70OrLater}} CompareLogic{{/net70OrLater}}({{#equatable}}comparisonConfig{{/equatable}});
+        }
+        {{/useCompareNetObjects}}
+
+        /// <summary>
+        /// A delegate for events.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        /// <returns></returns>
+        public delegate void EventHandler<T>(object sender, T e) where T : EventArgs;
+
+        {{#hasApiKeyMethods}}
+        /// <summary>
+        /// An enum of headers
+        /// </summary>
+        public enum ApiKeyHeader
+        {
+            {{#apiKeyMethods}}
+            /// <summary>
+            /// The {{keyParamName}} header
+            /// </summary>
+            {{#lambda.titlecase}}{{#lambda.alphabet_or_underscore}}{{keyParamName}}{{/lambda.alphabet_or_underscore}}{{/lambda.titlecase}}{{^-last}},{{/-last}}
+            {{/apiKeyMethods}}
+        }
+
+        /// <summary>
+        /// Converte an ApiKeyHeader to a string
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="System.ComponentModel.InvalidEnumArgumentException"></exception>
+        {{>visibility}} static string ApiKeyHeaderToString(ApiKeyHeader value)
+        {
+            {{#net80OrLater}}
+            return value switch
+            {
+                {{#apiKeyMethods}}
+                ApiKeyHeader.{{#lambda.titlecase}}{{#lambda.alphabet_or_underscore}}{{keyParamName}}{{/lambda.alphabet_or_underscore}}{{/lambda.titlecase}} => "{{keyParamName}}",
+                {{/apiKeyMethods}}
+                _ => throw new System.ComponentModel.InvalidEnumArgumentException(nameof(value), (int)value, typeof(ApiKeyHeader)),
+            };
+            {{/net80OrLater}}
+            {{^net80OrLater}}
+            switch(value)
+            {
+                {{#apiKeyMethods}}
+                case ApiKeyHeader.{{#lambda.titlecase}}{{#lambda.alphabet_or_underscore}}{{keyParamName}}{{/lambda.alphabet_or_underscore}}{{/lambda.titlecase}}:
+                    return "{{keyParamName}}";
+                {{/apiKeyMethods}}
+                default:
+                    throw new System.ComponentModel.InvalidEnumArgumentException(nameof(value), (int)value, typeof(ApiKeyHeader));
+            }
+            {{/net80OrLater}}
+        }
+
+        {{/hasApiKeyMethods}}
+        /// <summary>
+        /// Returns true when deserialization succeeds.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="json"></param>
+        /// <param name="options"></param>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        public static bool TryDeserialize<T>(string json, JsonSerializerOptions options, {{#net60OrLater}}[global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] {{/net60OrLater}}out T{{#nrt}}{{#net60OrLater}}?{{/net60OrLater}}{{/nrt}} result)
+        {
+            try
+            {
+                result = JsonSerializer.Deserialize<T>(json, options);
+                return result != null;
+            }
+            catch (Exception)
+            {
+                result = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true when deserialization succeeds.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="reader"></param>
+        /// <param name="options"></param>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        public static bool TryDeserialize<T>(ref Utf8JsonReader reader, JsonSerializerOptions options, {{#net60OrLater}}[global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] {{/net60OrLater}}out T{{#nrt}}{{#net60OrLater}}?{{/net60OrLater}}{{/nrt}} result)
+        {
+            try
+            {
+                result = JsonSerializer.Deserialize<T>(ref reader, options);
+                return result != null;
+            }
+            catch (Exception)
+            {
+                result = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// If parameter is DateTime, output in a formatted string (default ISO 8601), customizable with Configuration.DateTime.
+        /// If parameter is a list, join the list with ",".
+        /// Otherwise just return the string.
+        /// </summary>
+        /// <param name="obj">The parameter (header, path, query, form).</param>
+        /// <param name="format">The DateTime serialization format.</param>
+        /// <returns>Formatted string.</returns>
+        public static string{{nrt?}} ParameterToString(object{{nrt?}} obj, string{{nrt?}} format = ISO8601_DATETIME_FORMAT)
+        {
+            if (obj is DateTime dateTime)
+                // Return a formatted date string - Can be customized with Configuration.DateTimeFormat
+                // Defaults to an ISO 8601, using the known as a Round-trip date/time pattern ("o")
+                // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
+                // For example: 2009-06-15T13:45:30.0000000
+                return dateTime.ToString(format);
+            if (obj is DateTimeOffset dateTimeOffset)
+                // Return a formatted date string - Can be customized with Configuration.DateTimeFormat
+                // Defaults to an ISO 8601, using the known as a Round-trip date/time pattern ("o")
+                // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
+                // For example: 2009-06-15T13:45:30.0000000
+                return dateTimeOffset.ToString(format);
+            {{#net60OrLater}}
+            if (obj is DateOnly dateOnly)
+                return dateOnly.ToString(format);
+            {{/net60OrLater}}
+            if (obj is bool boolean)
+                return boolean
+                    ? "true"
+                    : "false";
+            {{#models}}
+            {{#model}}
+            {{#isEnum}}
+            if (obj is {{classname}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}})
+                {{! below has #isNumeric as a work around but should probably have ^isString instead https://github.com/OpenAPITools/openapi-generator/issues/15038}}
+                return {{classname}}ValueConverter.{{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}}ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}){{#isNumeric}}.ToString(){{/isNumeric}};
+            {{/isEnum}}
+            {{^isEnum}}
+            {{#vars}}
+            {{#items.isEnum}}
+            {{#items}}
+            {{^complexType}}
+            if (obj is {{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{{datatypeWithEnum}}}{{/lambda.camelcase_sanitize_param}})
+                {{! below has #isNumeric as a work around but should probably have ^isString instead https://github.com/OpenAPITools/openapi-generator/issues/15038}}
+                return {{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}}ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{{datatypeWithEnum}}}{{/lambda.camelcase_sanitize_param}}){{#isNumeric}}.ToString(){{/isNumeric}};
+            {{/complexType}}
+            {{/items}}
+            {{/items.isEnum}}
+            {{#isEnum}}
+            {{^complexType}}
+            if (obj is {{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{{datatypeWithEnum}}}{{/lambda.camelcase_sanitize_param}})
+                {{! below has #isNumeric as a work around but should probably have ^isString instead https://github.com/OpenAPITools/openapi-generator/issues/15038}}
+                return {{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}}ToJsonValue({{#lambda.camelcase_sanitize_param}}{{classname}}{{{datatypeWithEnum}}}{{/lambda.camelcase_sanitize_param}}){{#isNumeric}}.ToString(){{/isNumeric}};
+            {{/complexType}}
+            {{/isEnum}}
+            {{/vars}}
+            {{/isEnum}}
+            {{/model}}
+            {{/models}}
+            if (obj is ICollection collection)
+            {
+                List<string{{nrt?}}> entries = new{{^net70OrLater}} List<string{{nrt?}}>{{/net70OrLater}}();
+                foreach (var entry in collection)
+                    entries.Add(ParameterToString(entry));
+                return string.Join(",", entries);
+            }
+
+            return Convert.ToString(obj, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// URL encode a string
+        /// Credit/Ref: https://github.com/restsharp/RestSharp/blob/master/RestSharp/Extensions/StringExtensions.cs#L50
+        /// </summary>
+        /// <param name="input">string to be URL encoded</param>
+        /// <returns>Byte array</returns>
+        public static string UrlEncode(string input)
+        {
+            const int maxLength = 32766;
+
+            if (input == null)
+            {
+                throw new ArgumentNullException("input");
+            }
+
+            if (input.Length <= maxLength)
+            {
+                return Uri.EscapeDataString(input);
+            }
+
+            StringBuilder sb = new StringBuilder(input.Length * 2);
+            int index = 0;
+
+            while (index < input.Length)
+            {
+                int length = Math.Min(input.Length - index, maxLength);
+                string subString = input.Substring(index, length);
+
+                sb.Append(Uri.EscapeDataString(subString));
+                index += subString.Length;
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Encode string in base64 format.
+        /// </summary>
+        /// <param name="text">string to be encoded.</param>
+        /// <returns>Encoded string.</returns>
+        public static string Base64Encode(string text)
+        {
+            return Convert.ToBase64String(global::System.Text.Encoding.UTF8.GetBytes(text));
+        }
+
+        /// <summary>
+        /// Convert stream to byte array
+        /// </summary>
+        /// <param name="inputStream">Input stream to be converted</param>
+        /// <returns>Byte array</returns>
+        public static byte[] ReadAsBytes(Stream inputStream)
+        {
+            using (var ms = new MemoryStream())
+            {
+                inputStream.CopyTo(ms);
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Select the Content-Type header's value from the given content-type array:
+        /// if JSON type exists in the given array, use it;
+        /// otherwise use the first one defined in 'consumes'
+        /// </summary>
+        /// <param name="contentTypes">The Content-Type array to select from.</param>
+        /// <returns>The Content-Type header to use.</returns>
+        public static string{{nrt?}} SelectHeaderContentType(string[] contentTypes)
+        {
+            if (contentTypes.Length == 0)
+                return null;
+
+            foreach (var contentType in contentTypes)
+            {
+                if (IsJsonMime(contentType))
+                    return contentType;
+            }
+
+            return contentTypes[0]; // use the first content type specified in 'consumes'
+        }
+
+        /// <summary>
+        /// Select the Accept header's value from the given accepts array:
+        /// if JSON exists in the given array, use it;
+        /// otherwise use all of them (joining into a string)
+        /// </summary>
+        /// <param name="accepts">The accepts array to select from.</param>
+        /// <returns>The Accept header to use.</returns>
+        public static string{{nrt?}} SelectHeaderAccept(string[] accepts)
+        {
+            if (accepts.Length == 0)
+                return null;
+
+            if (accepts.Contains("application/json", StringComparer.OrdinalIgnoreCase))
+                return "application/json";
+
+            return string.Join(",", accepts);
+        }
+
+        /// <summary>
+        /// Provides a case-insensitive check that a provided content type is a known JSON-like content type.
+        /// </summary>
+    {{#net70OrLater}}
+        [GeneratedRegex("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$")]
+        private static partial Regex JsonRegex();
+    {{/net70OrLater}}
+    {{^net70OrLater}}
+        private static readonly Regex JsonRegex = new Regex("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+    {{/net70OrLater}}
+
+        /// <summary>
+        /// Check if the given MIME is a JSON MIME.
+        /// JSON MIME examples:
+        ///    application/json
+        ///    application/json; charset=UTF8
+        ///    APPLICATION/JSON
+        ///    application/vnd.company+json
+        /// </summary>
+        /// <param name="mime">MIME</param>
+        /// <returns>Returns True if MIME type is json.</returns>
+        public static bool IsJsonMime(string mime)
+        {
+            if (string.IsNullOrWhiteSpace(mime)) return false;
+
+            return {{#net70OrLater}}JsonRegex(){{/net70OrLater}}{{^net70OrLater}}JsonRegex{{/net70OrLater}}.IsMatch(mime) || mime.Equals("application/json-patch+json");
+        }
+
+        /// <summary>
+        /// Get the discriminator
+        /// </summary>
+        /// <param name="utf8JsonReader"></param>
+        /// <param name="discriminator"></param>
+        /// <returns></returns>
+        /// <exception cref="JsonException"></exception>
+        public static string{{nrt?}} GetDiscriminator(Utf8JsonReader utf8JsonReader, string discriminator)
+        {
+            int currentDepth = utf8JsonReader.CurrentDepth;
+
+            if (utf8JsonReader.TokenType != JsonTokenType.StartObject && utf8JsonReader.TokenType != JsonTokenType.StartArray)
+                throw new JsonException();
+
+            JsonTokenType startingTokenType = utf8JsonReader.TokenType;
+
+            while (utf8JsonReader.Read())
+            {
+                if (startingTokenType == JsonTokenType.StartObject && utf8JsonReader.TokenType == JsonTokenType.EndObject && currentDepth == utf8JsonReader.CurrentDepth)
+                    break;
+
+                if (startingTokenType == JsonTokenType.StartArray && utf8JsonReader.TokenType == JsonTokenType.EndArray && currentDepth == utf8JsonReader.CurrentDepth)
+                    break;
+
+                if (utf8JsonReader.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReader.CurrentDepth - 1)
+                {
+                    string{{nrt?}} localVarJsonPropertyName = utf8JsonReader.GetString();
+                    utf8JsonReader.Read();
+
+                    if (localVarJsonPropertyName != null && localVarJsonPropertyName.Equals(discriminator))
+                        return utf8JsonReader.GetString();
+                }
+            }
+
+            throw new JsonException("The specified discriminator was not found.");
+        }
+
+        // ============================================================================
+        // GasBuddy Custom: Configuration-driven host and API key support
+        // ============================================================================
+
+        /// <summary>
+        /// The configuration key prefix for app settings (e.g., "PackageName.Host", "PackageName.Key")
+        /// </summary>
+        public const string CONFIG_KEY_PREFIX = "{{packageName}}";
+
+        /// <summary>
+        /// Gets the base address from app.config/web.config, falling back to the default if not configured.
+        /// Reads from: ConfigurationManager.AppSettings["{{packageName}}.Host"]
+        /// </summary>
+        public static string BASE_ADDRESS
+        {
+            get
+            {
+                var configuredHost = ConfigurationManager.AppSettings[$"{CONFIG_KEY_PREFIX}.Host"];
+                return !string.IsNullOrEmpty(configuredHost) ? configuredHost : DEFAULT_BASE_ADDRESS;
+            }
+        }
+
+        /// <summary>
+        /// Gets the API key from app.config/web.config.
+        /// Reads from: ConfigurationManager.AppSettings["{{packageName}}.Key"]
+        /// </summary>
+        public static string{{nrt?}} ApiKey
+        {
+            get
+            {
+                return ConfigurationManager.AppSettings[$"{CONFIG_KEY_PREFIX}.Key"];
+            }
+        }
+
+        /// <summary>
+        /// The default base path of the API (used when not configured in app.config)
+        /// </summary>
+        public const string DEFAULT_BASE_ADDRESS = "{{{basePath}}}";
+
+        /// <summary>
+        /// The scheme of the API
+        /// </summary>
+        public const string SCHEME = "{{{scheme}}}";
+
+        /// <summary>
+        /// The context path of the API
+        /// </summary>
+        public const string CONTEXT_PATH = "{{contextPath}}";
+
+        /// <summary>
+        /// The host of the API
+        /// </summary>
+        public const string HOST = "{{{host}}}";
+
+        /// <summary>
+        /// The format to use for DateTime serialization
+        /// </summary>
+        public const string ISO8601_DATETIME_FORMAT = "o";
+    }
+}

--- a/openapi-templates/csharp-gasbuddy/libraries/generichost/ClientUtils.mustache
+++ b/openapi-templates/csharp-gasbuddy/libraries/generichost/ClientUtils.mustache
@@ -414,12 +414,12 @@ using System.Runtime.CompilerServices;
         /// <summary>
         /// The default base path of the API (used when not configured in app.config)
         /// </summary>
-        public const string DEFAULT_BASE_ADDRESS = "{{{basePath}}}";
+        public const string DEFAULT_BASE_ADDRESS = "{{basePath}}";
 
         /// <summary>
         /// The scheme of the API
         /// </summary>
-        public const string SCHEME = "{{{scheme}}}";
+        public const string SCHEME = "{{scheme}}";
 
         /// <summary>
         /// The context path of the API
@@ -429,7 +429,7 @@ using System.Runtime.CompilerServices;
         /// <summary>
         /// The host of the API
         /// </summary>
-        public const string HOST = "{{{host}}}";
+        public const string HOST = "{{host}}";
 
         /// <summary>
         /// The format to use for DateTime serialization


### PR DESCRIPTION
Document how to generate C# clients from OpenAPI 3.x specs using OpenAPI Generator as an alternative to swagger-codegen. Includes:

- Docker-based workflow (no Java installation required)
- Target framework options (.NET Framework 4.7/4.8, .NET Standard, .NET 8/9)
- Custom template instructions
- CI/CD integration example
- Comparison with current swagger-csharp-client approach